### PR TITLE
Guardar nombres de usuarios y uuids en DB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>EdorasSoul BungeeCord</name>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -90,6 +90,11 @@
             <artifactId>PremiumVanishAPI</artifactId>
             <version>2.0.3</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.0.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/github/kikisito/bungee/edorassoul/Database.java
+++ b/src/main/java/com/github/kikisito/bungee/edorassoul/Database.java
@@ -1,0 +1,44 @@
+package com.github.kikisito.bungee.edorassoul;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Clase para gestionar el pool de conexiones a la base de datos
+ */
+public class Database {
+
+    private final HikariDataSource dataSource;
+
+    public Database() {
+        final String host = Main.config.getString("database.host");
+        final String port = Main.config.getString("database.port");
+        final String database = Main.config.getString("database.dbname");
+        final String username = Main.config.getString("database.username");
+        final String password = Main.config.getString("database.password");
+
+        final HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database);
+        hikariConfig.setUsername(username);
+        hikariConfig.setPassword(password);
+        hikariConfig.addDataSourceProperty("cachePrepStmts", "true");
+        hikariConfig.addDataSourceProperty("prepStmtCacheSize", "250");
+        hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+        hikariConfig.addDataSourceProperty("useServerPrepStmts", "true");
+
+        // Iniciar el DataSource
+        this.dataSource = new HikariDataSource(hikariConfig);
+    }
+
+    /**
+     * Devuelve una conexión a la base de datos del pool
+     * @return Connection
+     * @throws SQLException si la conexión está cerrada
+     */
+    public Connection getConnection() throws SQLException {
+        return this.dataSource.getConnection();
+    }
+}

--- a/src/main/java/com/github/kikisito/bungee/edorassoul/Main.java
+++ b/src/main/java/com/github/kikisito/bungee/edorassoul/Main.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 public final class Main extends Plugin {
     public static ZinciteBot telegramBot;
     public static Configuration config;
+    public Database database;
     private ScheduledTask task;
 
     public List<Integer> protocolId = new ArrayList<>();
@@ -41,6 +42,8 @@ public final class Main extends Plugin {
     @Override
     public void onEnable() {
         this.loadConfig();
+        this.database = new Database();
+
         this.getProxy().getPluginManager().registerCommand(this, new PendingFormsCommand(this));
         this.getProxy().getPluginManager().registerCommand(this, new SendAdCommand(this));
         this.getProxy().getPluginManager().registerCommand(this, new VoyCommand(this));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,6 +3,13 @@ new-forms-link: ""
 
 telegram-bot-token: ""
 
+database:
+  host: ""
+  port: ""
+  dbname: ""
+  username: ""
+  password: ""
+
 publicidad:
   period: 900
   format: "&8[&7Publicidad&8] &b{message}"


### PR DESCRIPTION
Antes de la instalación, no olvidarnos de desinstalar el plugin ya por separado que ya tiene esta funcionalidad (Edoras-UUIDNames) y configurar correctamente el acceso a DB